### PR TITLE
feat: add version selector

### DIFF
--- a/src/components/home/Banner.tsx
+++ b/src/components/home/Banner.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import GitHubButton from 'react-github-button';
 import QueueAnim from 'rc-queue-anim';
-import { Button } from 'antd';
+import { Button, Tag } from 'antd';
 import { Link } from 'gatsby';
 import { FormattedMessage } from 'react-intl';
 import { isZhCN, getLocalizedPathname } from '../utils';
 import { version } from '../../../siteconfig.json';
+import { GithubOutlined } from '@ant-design/icons';
 
 function Banner(props) {
   const { isMobile, location } = props;
@@ -13,22 +13,26 @@ function Banner(props) {
     <section className="home-section home-section-banner">
       <div className='home-flex'>
         <QueueAnim type={isMobile ? 'bottom' : 'right'}>
-          <h1><img src="https://gw.alipayobjects.com/mdn/rms_d27172/afts/img/A*Xwt7RZ-2FrUAAAAAAAAAAAAAARQnAQ" alt="Oasis Engine" /></h1>
-          <p>
+          <h1>
+            <img src="https://gw.alipayobjects.com/mdn/rms_d27172/afts/img/A*Xwt7RZ-2FrUAAAAAAAAAAAAAARQnAQ" alt="Oasis Engine" />
+          </h1>
+          <p className="description">
+            <Tag>v{version}</Tag>
+            &nbsp;
             <FormattedMessage id="app.home.slogan" />
-          </p>
-          <p>
-            <GitHubButton
-              key="github-button"
-              type="stargazers"
-              namespace="oasis-engine"
-              repo="engine"
-            />
           </p>
           <div className="button-wrapper">
             <Link to={getLocalizedPathname(`${version}/docs/install`, isZhCN(location.pathname))}>
               <Button type="primary">
                 <FormattedMessage id="app.home.start" />
+              </Button>
+            </Link>
+            &nbsp;
+            &nbsp;
+            <Link to="https://github.com/oasis-engine/engine" target="_blank">
+              <Button type="primary" ghost>
+                <GithubOutlined />
+                Github
               </Button>
             </Link>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { Link } from 'gatsby';
-import { AppstoreAddOutlined, HomeOutlined, MenuOutlined, NotificationOutlined, ReadOutlined, SearchOutlined } from '@ant-design/icons';
+import { AppstoreAddOutlined, HomeOutlined, MenuOutlined, NotificationOutlined, PlayCircleOutlined, ReadOutlined, SearchOutlined } from '@ant-design/icons';
 import { Row, Col, Select, Input, Menu, Popover } from 'antd';
 import * as utils from '../utils';
 import { version } from '../../../siteconfig.json';
@@ -207,11 +207,6 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                 API
               </Link>
             </Menu.Item>
-            <Menu.Item key="examples">
-              <Link to={`/${version}/examples`}>
-                {formatMessage({ id: "app.header.menu.engine.examples" })}
-              </Link>
-            </Menu.Item>
           </Menu.ItemGroup>
           <Menu.ItemGroup title={formatMessage({ id: "app.header.menu.editor" })}>
             <Menu.Item key="editor-docs">
@@ -221,6 +216,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
             </Menu.Item>
           </Menu.ItemGroup>
         </Menu.SubMenu>
+        <Menu.Item key="examples" icon={<PlayCircleOutlined />}>
+          <Link to={`/${version}/examples`}>
+            <FormattedMessage id="app.header.menu.engine.examples" />
+          </Link>
+        </Menu.Item>
         <Menu.SubMenu key="ecosystem" icon={<AppstoreAddOutlined />} title={formatMessage({ id: "app.header.menu.ecosystem" })}>
           <Menu.ItemGroup title={formatMessage({ id: "app.header.menu.ecosystem.tool" })}>
             <Menu.Item key="gltfviewer">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,7 +6,7 @@ import { Row, Col, Select, Input, Menu, Popover } from 'antd';
 import * as utils from '../utils';
 import { version } from '../../../siteconfig.json';
 
-// const { Option } = Select;
+const { Option } = Select;
 
 const LOGO_URL = 'https://gw.alipayobjects.com/mdn/rms_d27172/afts/img/A*w3sZQpMix18AAAAAAAAAAAAAARQnAQ';
 
@@ -58,6 +58,7 @@ interface HeaderState {
   menuMode?: 'vertical' | 'vertical-left' | 'vertical-right' | 'horizontal' | 'inline';
   searchOption?: any[];
   searching?: boolean;
+  versions?: string[]
 }
 
 class Header extends React.Component<HeaderProps, HeaderState> {
@@ -69,11 +70,12 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     super(props);
     this.state = {
       menuVisible: false,
-      menuMode: props.isMobile ? 'inline' : 'horizontal'
+      menuMode: props.isMobile ? 'inline' : 'horizontal',
+      versions: []
     };
   }
 
-  componentDidMount() {
+  async componentDidMount() {
     const { searchInput } = this;
     const { intl: { locale } } = this.props;
 
@@ -86,6 +88,14 @@ class Header extends React.Component<HeaderProps, HeaderState> {
     });
 
     initDocSearch(locale === 'zh-CN' ? 'cn' : 'en');
+
+    // Fetch version from remote config
+    const versionConfig = 'https://render.alipay.com/p/h5data/oasis-version_site-doc-versions-h5data.json';
+    const versions = await fetch(versionConfig).then((e) => e.json());
+    
+    if (versions) {
+      this.setState({ versions: versions.map((v) => v.version)}) 
+    }
   }
 
   componentDidUpdate(preProps: HeaderProps) {
@@ -140,11 +150,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
   };
 
   onVersionChange = (value: string) => {
-    if (value === 'v1') {
-      window.open('https://v1.pro.ant.design/');
-    }
-    if (value === 'v2') {
-      window.open('https://v2-pro.ant.design/');
+    const versionReg = /\/(\d+[.]\d+[^/]*)\//;
+    const matchedResult = location.href.match(versionReg);
+    
+    if (matchedResult && matchedResult[1]) {
+      location.href = location.href.replace(matchedResult[1], value);
     }
   };
 
@@ -187,7 +197,7 @@ class Header extends React.Component<HeaderProps, HeaderState> {
         </Menu.Item>
         <Menu.SubMenu key="docs" icon={<ReadOutlined />} title={formatMessage({ id: "app.header.menu.docs" })}>
           <Menu.ItemGroup title={formatMessage({ id: "app.header.menu.engine" })}>
-            <Menu.Item key="docs">
+            <Menu.Item key="engine-docs">
               <Link to={utils.getLocalizedPathname(`${version}/docs/install`, isZhCN)}>
                 {formatMessage({ id: "app.header.menu.engine.docs" })}
               </Link>
@@ -278,11 +288,11 @@ class Header extends React.Component<HeaderProps, HeaderState> {
                       <FormattedMessage id="app.header.lang" />
                     </Button>
                   </div> */}
-                  {/* {this.props.showVersion && <Select size="small" onChange={this.onVersionChange} value="stable">
-                    <Option value="0.1">v0.1</Option>
-                    <Option value="0.2">v0.2</Option>
-                    <Option value="0.3">v0.3</Option>
-                  </Select>} */}
+                  {this.state.versions.length && this.props.showVersion && <Select size="small" onChange={this.onVersionChange} value={version}>
+                    {this.state.versions.map((v)=> {
+                      return <Option value={v} key={v}>{`v${v}`}</Option>
+                    })}
+                  </Select>}
                 </div>
                 {menuMode === 'horizontal' ? <div id="menu">{menu}</div> : null}
               </div>

--- a/src/pages/examples.tsx
+++ b/src/pages/examples.tsx
@@ -74,7 +74,7 @@ export default function Examples(props: any) {
 
   return (
     <>
-      <WrapperLayout {...props}>
+      <WrapperLayout {...props} showVersion="true">
         <Media query="(max-width: 599px)">
           {(isMobile) =>
             <Layout hasSider={true}>

--- a/src/static/header.less
+++ b/src/static/header.less
@@ -75,7 +75,7 @@
 #menu {
   float: right;
   overflow: hidden;
-  width: 400px;
+  width: 500px;
   height: 64px;
   .ant-menu {
     line-height: 60px;

--- a/src/static/home.less
+++ b/src/static/home.less
@@ -109,6 +109,11 @@
   p {
     font-size: 20px;
   }
+  .description {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
   .github-btn {
     display: inline-block;
     height: 28px;

--- a/src/templates/api.tsx
+++ b/src/templates/api.tsx
@@ -27,7 +27,7 @@ export default function API (props: any) {
 
   return (
     <>
-      <WrapperLayout {...props}>
+      <WrapperLayout {...props} showVersion="true">
         <Media query="(max-width: 599px)">
           {(isMobile) => 
           <Layout hasSider={true}>


### PR DESCRIPTION
- Add version selector: Fetch versions data from remote config. Only show version selector in *docs*、*API*、*examples* pages.
- Move *examples* submenu to top menu.
- Add current version label in homepage.
- Change github Button to ghost button. 