### PR TITLE
chore: fix example/api/doc link on markdown page

### DIFF
--- a/src/components/doc/index.tsx
+++ b/src/components/doc/index.tsx
@@ -127,7 +127,7 @@ function Doc() {
     ></DocMenu>
   );
 
-  const docDetail = <DocDetail selectedDocId={selectedDocId}></DocDetail>;
+  const docDetail = <DocDetail {...{ selectedDocId, setSelectedDocId, menuKeyTitleMapRef }}></DocDetail>;
 
   return (
     <Media query='(max-width: 768px)'>

--- a/src/components/doc/plugins/playground.ts
+++ b/src/components/doc/plugins/playground.ts
@@ -1,7 +1,6 @@
 import { visit } from "unist-util-visit";
 
-// eslint-disable-next-line import/no-anonymous-default-export
-export default () => {
+export default function() {
   return (markdownAST: any) => {
     visit(markdownAST, 'html', (node, i, parent) => {
       if (node.value.includes('<playground')) {

--- a/src/siteconfig.json
+++ b/src/siteconfig.json
@@ -1,5 +1,4 @@
 {
-  "token": "Github access token",
   "name": "oasis-engine",
   "version": "0.8",
   "versions": ["latest", "0.8", "0.7", "0.6", "0.5", "0.4", "0.3", "0.2"],


### PR DESCRIPTION
fix: link address in markdown